### PR TITLE
Update README to remove PHP notice in an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Once the $client object is created, you can begin to use the API.
 #### Get current balance
 ```php5
 <?php
-  echo $client->account_balance();
+  print_r($client->account_balance());
 ?>
 ```
 #### Get outstanding payment requests


### PR DESCRIPTION
account_balance() returns an array, so trying to echo it generates a PHP notice "Array to string conversion"